### PR TITLE
fixed contentEditable for windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,13 @@ function captureBackspace(e) {
   var rx = /INPUT|SELECT|TEXTAREA/i;
 
   if( e.which == 8 ){ // 8 == backspace
-    if(e.target.contentEditable) return;
+    
+    if(e.target.getAttribute('contenteditable') !== null) return;
+
     if(!rx.test(e.target.tagName) || e.target.disabled || e.target.readOnly) {
       e.preventDefault();
     }
+  
   }
 }
 


### PR DESCRIPTION
Bug fix: the previous version of prevent-backspace for content-editable fields did not works under windows.
Now it works under OSX, Linux and Windows
